### PR TITLE
Add Jackson deserialization and implement JAX-RS *Params 

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ application.addPackagesToScan("<package to scan>");
 
 HttpServer server = vertx.createHttpServer();
 
-application.addSingleton(vertx);
+application.addSingleton(vertx, new ObjectMapper());
 
 RouteMatcherBuilder builder = new JaxrsRouteMatcherBuilder(application);
 server.requestHandler(builder.build());

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Current Support
 
 TODO
 ====
-Check issues
+- Enums support - see me.bayes.vertx.vest.util.JaxrsAnnotationParamterHandler
+- ...
 
 Introduction
 ============

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Current Support
 TODO
 ====
 - Enums support - see me.bayes.vertx.vest.util.JaxrsAnnotationParamterHandler
+- Custom objects deserialization support
+- Validation support
 - ...
 
 Introduction

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <version>0.2.0</version>
   <name>Vest Framework</name>
   <description>Jaxrs extension for creating REST services with Vertx</description>
-  
+
   <licenses>
   	<license>
   		<name>Apache License 2.0</name>
@@ -18,7 +18,7 @@
   	<url>https://github.com/kevinbayes/vertx-route-ext</url>
   	<connection>https://github.com/kevinbayes/vertx-route-ext.git</connection>
   </scm>
-  
+
   <developers>
   	<developer>
   		<id>kevinbayes</id>
@@ -30,16 +30,17 @@
   		</roles>
   	</developer>
   </developers>
-  
+
   <properties>
-  	<vertx.version>2.1.1</vertx.version>
+  	<vertx.version>2.1.5</vertx.version>
   	<vertx.test.version>2.0.3-final</vertx.test.version>
   	<vertx.test.framework.version>2.0.0-final</vertx.test.framework.version>
   	<jaxrs.version>2.0</jaxrs.version>
   	<junit.version>4.11</junit.version>
+  	<jackson.version>2.5.2</jackson.version>
   </properties>
-  
-  
+
+
   <dependencies>
   	<dependency>
   		<groupId>io.vertx</groupId>
@@ -47,21 +48,21 @@
   		<version>${vertx.version}</version>
   		<scope>provided</scope>
   	</dependency>
-  	
+
   	<dependency>
 	    <groupId>io.vertx</groupId>
 	    <artifactId>vertx-platform</artifactId>
 	    <version>${vertx.version}</version>
 	    <scope>provided</scope>
 	</dependency>
-  	
+
 	<dependency>
 	    <groupId>io.vertx</groupId>
     	<artifactId>testtools</artifactId>
 	    <version>${vertx.test.version}</version>
 	    <scope>test</scope>
 	</dependency>
-	
+
 	<dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-testframework</artifactId>
@@ -74,8 +75,23 @@
 	    <artifactId>javax.ws.rs-api</artifactId>
 	    <version>${jaxrs.version}</version>
 	</dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+	  <dependency>
+		  <groupId>com.github.drapostolos</groupId>
+		  <artifactId>type-parser</artifactId>
+		  <version>0.5.0</version>
+	  </dependency>
 
-  	<dependency>
+	  <dependency>
   		<groupId>junit</groupId>
   		<artifactId>junit</artifactId>
   		<version>${junit.version}</version>
@@ -83,7 +99,7 @@
   	</dependency>
 
   </dependencies>
-  
+
   <build>
   	<plugins>
   		<plugin>
@@ -112,21 +128,9 @@
 		    </execution>
 		  </executions>
 		</plugin>
-		<plugin>
-		  <groupId>org.apache.maven.plugins</groupId>
-		  <artifactId>maven-javadoc-plugin</artifactId>
-		  <executions>
-		    <execution>
-		      <id>attach-javadocs</id>
-		      <goals>
-		        <goal>jar</goal>
-		      </goals>
-		    </execution>
-		  </executions>
-		</plugin>
   	</plugins>
   </build>
-  
+
   <reporting>
     <plugins>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>me.bayes</groupId>
   <artifactId>vest-framework</artifactId>
-  <version>0.2.0</version>
+  <version>0.2.1</version>
   <name>Vest Framework</name>
   <description>Jaxrs extension for creating REST services with Vertx</description>
 

--- a/src/main/java/me/bayes/vertx/vest/AbstractRouteMatcherBuilder.java
+++ b/src/main/java/me/bayes/vertx/vest/AbstractRouteMatcherBuilder.java
@@ -15,10 +15,8 @@
  */
 package me.bayes.vertx.vest;
 
-import me.bayes.vertx.vest.binding.DefaultRouteBindingHolderFactory;
 import me.bayes.vertx.vest.binding.RouteBindingHolder;
 import me.bayes.vertx.vest.binding.RouteBindingHolderFactory;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.vertx.java.core.Handler;
@@ -36,7 +34,6 @@ public abstract class AbstractRouteMatcherBuilder implements RouteMatcherBuilder
 	protected RouteMatcher routeMatcher;
 	protected RouteBindingHolderFactory bindingHolderFactory;
 	protected RouteBindingHolder bindingHolder;
-	protected Handler<HttpServerRequest> exceptionHandler;
 
 	public AbstractRouteMatcherBuilder(VestApplication application,
 			RouteBindingHolderFactory bindingHolderFactory) {
@@ -102,16 +99,6 @@ public abstract class AbstractRouteMatcherBuilder implements RouteMatcherBuilder
 	 */
 	public void setNoRouteHandler(Handler<HttpServerRequest> handler) {
 		routeMatcher.noMatch(handler);
-	}
-	
-	/*
-	 *  TODO: Add the implemetation required by the specification.
-	 *  
-	 * (non-Javadoc)
-	 * @see me.bayes.vertx.vest.RouteMatcherBuilder#setExceptionHandler(org.vertx.java.core.Handler)
-	 */
-	public void setExceptionHandler(Handler<HttpServerRequest> handler) {	
-		this.exceptionHandler = handler;
 	}
 	
 }

--- a/src/main/java/me/bayes/vertx/vest/DefaultRouteMatcherBuilder.java
+++ b/src/main/java/me/bayes/vertx/vest/DefaultRouteMatcherBuilder.java
@@ -15,34 +15,24 @@
  */
 package me.bayes.vertx.vest;
 
-import java.io.IOException;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.List;
-
-import javax.ws.rs.*;
-import javax.ws.rs.core.Application;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MediaType;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import me.bayes.vertx.vest.binding.DefaultRouteBindingHolderFactory;
 import me.bayes.vertx.vest.binding.Function;
 import me.bayes.vertx.vest.binding.RouteBindingHolder.MethodBinding;
+import me.bayes.vertx.vest.handler.HttpServerRequestHandler;
 import me.bayes.vertx.vest.util.DefaultParameterResolver;
 import me.bayes.vertx.vest.util.ParameterResolver;
 import me.bayes.vertx.vest.util.UriPathUtil;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.vertx.java.core.Handler;
-import org.vertx.java.core.buffer.Buffer;
-import org.vertx.java.core.http.HttpServerRequest;
-import org.vertx.java.core.http.HttpServerResponse;
 import org.vertx.java.core.http.RouteMatcher;
-import org.vertx.java.core.json.JsonObject;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.Application;
+import javax.ws.rs.core.Context;
+import java.lang.reflect.Method;
+import java.util.List;
 
 /**
  * <pre>
@@ -80,17 +70,12 @@ public class DefaultRouteMatcherBuilder extends AbstractRouteMatcherBuilder {
 	private static final Logger LOG = LoggerFactory.getLogger(DefaultRouteMatcherBuilder.class);
 	
 	private final ParameterResolver parameterResolver;
-	
-	/**
-	 * Requires a {@link VestContext}.
-	 * @param context
-	 */
+
 	public DefaultRouteMatcherBuilder(final VestApplication application) {
 		super(application, new DefaultRouteBindingHolderFactory(application));
 		this.parameterResolver = new DefaultParameterResolver(application);
 	}
 
-	
 	/*
 	 * (non-Javadoc)
 	 * @see me.bayes.vertx.extension.RouteMatcherBuilder#build(me.bayes.vertx.extension.BuilderContext)
@@ -108,6 +93,8 @@ public class DefaultRouteMatcherBuilder extends AbstractRouteMatcherBuilder {
 	 * @throws Exception
 	 */
 	private void addRoutes(final RouteMatcher routeMatcher) throws Exception {
+		final ObjectMapper objectMapper = application.getSingleton(ObjectMapper.class);
+
 		this.bindingHolder.foreach(new Function() {
 			public void apply(final String method, final String key, final List<MethodBinding> bindings) throws Exception {
 				
@@ -118,217 +105,14 @@ public class DefaultRouteMatcherBuilder extends AbstractRouteMatcherBuilder {
 							Handler.class);
 				
 				final String finalPath = UriPathUtil.convertPath(key);
+				LOG.info(String.format("Added %s %s to be handled by %s", method, routeMatcherMethod, finalPath));
 				
 				routeMatcherMethod.invoke(routeMatcher, finalPath,
-						new Handler<HttpServerRequest>() {
-					
-					private List<MethodBinding> delegates;
-					
-					{
-						delegates = bindings;
-					}
-					
-					public void handle(HttpServerRequest request) {
-						
-						try {
-						
-							MethodBinding binding = null;
-							Method method = null;
-							
-							String acceptsHeader = request.headers().get(HttpHeaders.ACCEPT);
-							String contentTypeHeader = request.headers().get(HttpHeaders.CONTENT_TYPE);
-							
-							if(!request.headers().isEmpty()) {
-								for(MethodBinding binding_ : bindings) {
-									if(binding_.hasConsumes(contentTypeHeader) && binding_.hasProduces(acceptsHeader)) {
-										binding = binding_;
-										break;
-									}
-									if(binding_.hasConsumes(contentTypeHeader) && acceptsHeader == null) {
-										binding = binding_;
-										break;
-									}
-									if(contentTypeHeader == null && binding_.hasProduces(acceptsHeader)) {
-										binding = binding_;
-										break;
-									}
-								}
-								
-							}
-								
-							if(binding == null && delegates.size() > 0) {
-								binding = delegates.get(0);
-							} else if(binding == null){
-								throw new Exception("No route that supports accepts given HTTP parameters");
-							}
-							
-							method = binding.getMethod();
-							
-							final Class<?>[] parameterTypes = method.getParameterTypes();
-							if(parameterTypes.length == 0 || !parameterTypes[0].equals(HttpServerRequest.class)) {
-								LOG.warn("Classes marked with a HttpMethod must have at least one parameter. The first parameter should be HttpServerRequest.");
-								return;
-							}
-							
-							final Annotation[][] parameterAnnotations = method.getParameterAnnotations();
-							final String[] produces = binding.getProduces();
-							final String[] consumes = binding.getConsumes();
-							String producesMediaType = null;
-							
-							if(acceptsHeader != null) {
-								if(produces != null && produces.length > 0) {
-									for(String type : produces) {
-										if(acceptsHeader.contains(type)) {
-											producesMediaType = type;
-											break;
-										}
-									}
-								}
-							}
-							
-							if(producesMediaType == null) {
-								producesMediaType = 
-										(produces != null && produces.length == 1) ? 
-												produces[0] : MediaType.TEXT_PLAIN;
-							} 
-							
-							if(contentTypeHeader != null) {
-								if(consumes != null && consumes.length > 0) {
-									for(String type : consumes) {
-										if(acceptsHeader.contains(type)) {
-											contentTypeHeader = type;
-											break;
-										}
-									}
-								}
-							}
-							
-							request.response().headers().set(HttpHeaders.CONTENT_TYPE, producesMediaType);
-							
-							final Object[] parameters = new Object[parameterTypes.length];
-							parameters[0] = request;
-							
-							boolean isBodyResolved = false;
-							boolean deserializeUsingJackson = false;
-							int objectParameterIndex = -1;
-							
-							if(parameters.length > 1) {
-								for(int i = 1; i < parameters.length; i++) {
-									if(hasJaxRsAnnotations(parameterAnnotations[i]) ||
-											HttpServerResponse.class.equals(parameterTypes[i])) {
-										
-										parameters[i] = parameterResolver.resolve(method, parameterTypes[i], parameterAnnotations[i], request);
-										
-									} else if(JsonObject.class.equals(parameterTypes[i])) {
-										objectParameterIndex  = i;
-										isBodyResolved = true;
-										deserializeUsingJackson = false;
-									} else {
-										objectParameterIndex  = i;
-										isBodyResolved = true;
-										deserializeUsingJackson = true;
-									}
-								}
-							}
-							
-							if(isBodyResolved) {
-								resolvedBodyDelegate(binding.getDelegate(), request, objectParameterIndex, method, parameters, parameterTypes, deserializeUsingJackson);
-							} else {
-								delegate(binding.getDelegate(), method, parameters);
-							}
-						
-						} catch (Exception e) {
-							LOG.error("Exception occurred.", e);
-							
-							if(exceptionHandler != null) {
-								exceptionHandler.handle(request);
-							} else {
-								request.response().headers().set(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_PLAIN);
-								request.response().setStatusCode(500);
-								request.response().setStatusMessage("Internal server error");
-								request.response().end();
-							}
-						}
-						
-								
-					}
-					
-					private void delegate(Object delegate, Method method, Object[] parameters) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
-						method.invoke(delegate, parameters);
-					}
-					
-					private void resolvedBodyDelegate(final Object delegate, final HttpServerRequest request,
-													  final int objectParameterIndex, final Method method,
-													  final Object[] parameters, final Class<?>[] parameterTypes, final boolean deserializeUsingJackson) {
-						
-						final Buffer buffer = new Buffer();
-						
-						request.dataHandler(new Handler<Buffer>() {
-
-							@Override
-							public void handle(Buffer internalBuffer) {
-								buffer.appendBuffer(internalBuffer);
-							}
-							
-						});
-						
-						request.endHandler(new Handler<Void>() {
-
-							@Override
-							public void handle(Void event) {
-								String jsonString = buffer.toString();
-								if (deserializeUsingJackson) {
-									try {
-										parameters[objectParameterIndex] = application
-												.getSingleton(ObjectMapper.class)
-												.readValue(jsonString, parameterTypes[objectParameterIndex]);
-									} catch (IOException e) {
-										handleException(e);
-									}
-								} else {
-									parameters[objectParameterIndex] = new JsonObject(jsonString);
-								}
-
-								try {
-									method.invoke(delegate, parameters);
-								} catch (Exception e) {
-									handleException(e);
-								}
-							}
-
-							private void handleException(Exception e) {
-								LOG.error("Exception occurred.", e);
-
-								if(exceptionHandler != null) {
-									exceptionHandler.handle(request);
-								} else {
-									request.response().setStatusCode(500);
-									request.response().setStatusMessage("Internal server error");
-									request.response().end();
-								}
-							}
-						});
-					}
-					
-				});
+						new HttpServerRequestHandler(bindings, parameterResolver, objectMapper));
 				
 			}
 		});
 	}
 
-	private boolean hasJaxRsAnnotations(Annotation[] parameterAnnotation) {
-		for (Annotation annotation : parameterAnnotation) {
-			if (annotation.annotationType() == BeanParam.class ||
-					annotation.annotationType() == CookieParam.class ||
-					annotation.annotationType() == FormParam.class ||
-					annotation.annotationType() == HeaderParam.class ||
-					annotation.annotationType() == MatrixParam.class ||
-					annotation.annotationType() == PathParam.class ||
-					annotation.annotationType() == QueryParam.class) {
-				return true;
-			}
-		}
-		return false;
-	}
 
 }

--- a/src/main/java/me/bayes/vertx/vest/DefaultRouteMatcherBuilder.java
+++ b/src/main/java/me/bayes/vertx/vest/DefaultRouteMatcherBuilder.java
@@ -105,8 +105,7 @@ public class DefaultRouteMatcherBuilder extends AbstractRouteMatcherBuilder {
 							Handler.class);
 				
 				final String finalPath = UriPathUtil.convertPath(key);
-				LOG.info(String.format("Added %s %s to be handled by %s", method, finalPath, routeMatcherMethod));
-				
+
 				routeMatcherMethod.invoke(routeMatcher, finalPath,
 						new HttpServerRequestHandler(bindings, parameterResolver, objectMapper));
 				

--- a/src/main/java/me/bayes/vertx/vest/DefaultRouteMatcherBuilder.java
+++ b/src/main/java/me/bayes/vertx/vest/DefaultRouteMatcherBuilder.java
@@ -105,7 +105,7 @@ public class DefaultRouteMatcherBuilder extends AbstractRouteMatcherBuilder {
 							Handler.class);
 				
 				final String finalPath = UriPathUtil.convertPath(key);
-				LOG.info(String.format("Added %s %s to be handled by %s", method, routeMatcherMethod, finalPath));
+				LOG.info(String.format("Added %s %s to be handled by %s", method, finalPath, routeMatcherMethod));
 				
 				routeMatcherMethod.invoke(routeMatcher, finalPath,
 						new HttpServerRequestHandler(bindings, parameterResolver, objectMapper));

--- a/src/main/java/me/bayes/vertx/vest/RouteMatcherBuilder.java
+++ b/src/main/java/me/bayes/vertx/vest/RouteMatcherBuilder.java
@@ -52,13 +52,6 @@ public interface RouteMatcherBuilder {
 	 */
 	void setApplication(VestApplication application);
 	
-	
-	/**
-	 * @param handler for exception;
-	 */
-	void setExceptionHandler(Handler<HttpServerRequest> handler);
-	
-	
 	/**
 	 * This method should be overridden if a better no match is needed besides the 
 	 * default of a 404.

--- a/src/main/java/me/bayes/vertx/vest/VestApplication.java
+++ b/src/main/java/me/bayes/vertx/vest/VestApplication.java
@@ -15,6 +15,7 @@
  */
 package me.bayes.vertx.vest;
 
+import java.io.File;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
@@ -29,6 +30,7 @@ import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Application;
 
+import com.github.drapostolos.typeparser.TypeParser;
 import me.bayes.vertx.vest.deploy.RootContextVestApplication;
 
 import org.vertx.java.core.logging.Logger;
@@ -52,10 +54,19 @@ import org.vertx.java.platform.impl.java.PackageHelper;
 public abstract class VestApplication extends Application {
 	
 	private final static Logger LOG = LoggerFactory.getLogger(VestApplication.class);
-	
+
+	public VestApplication() {
+		TypeParser typeParser = TypeParser
+				.newBuilder()
+				.unregisterParser(Object.class)
+				.unregisterParser(File.class)
+				.build();
+		singletons.add(typeParser);
+	}
+
 	/*
-	 * Classloader to load scanned classes.
-	 */
+         * Classloader to load scanned classes.
+         */
 	private ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
 	
 	/*
@@ -92,7 +103,17 @@ public abstract class VestApplication extends Application {
 	public Set<Object> getSingletons() {
 		return singletons;
 	}
-	
+
+	public <T> T getSingleton(Class<? extends T> type) {
+		for(Object object : singletons) {
+			if(type.isInstance(object)) {
+				return (T)object;
+			}
+		}
+
+		return null;
+	}
+
 	@Override
 	public Map<String, Object> getProperties() {
 		return properties;

--- a/src/main/java/me/bayes/vertx/vest/binding/DefaultRouteBindingHolderFactory.java
+++ b/src/main/java/me/bayes/vertx/vest/binding/DefaultRouteBindingHolderFactory.java
@@ -15,21 +15,20 @@
  */
 package me.bayes.vertx.vest.binding;
 
-import java.lang.reflect.Method;
-import java.util.Set;
+import me.bayes.vertx.vest.VestApplication;
+import me.bayes.vertx.vest.util.ContextUtil;
+import me.bayes.vertx.vest.util.HttpUtils;
+import me.bayes.vertx.vest.util.UriPathUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-
-import me.bayes.vertx.vest.VestApplication;
-import me.bayes.vertx.vest.util.ContextUtil;
-import me.bayes.vertx.vest.util.HttpUtils;
-import me.bayes.vertx.vest.util.UriPathUtil;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Set;
 
 /**
  * @author Kevin Bayes
@@ -123,7 +122,7 @@ public class DefaultRouteBindingHolderFactory implements
 		}
 		
 		//3.3.1	Visibility Only public methods may be exposed as resource methods.
-		if(method.getModifiers() != Method.PUBLIC) {
+		if( !Modifier.isPublic(method.getModifiers())) {
 			LOG.warn("Method {} is not public and is annotated with @Path.", method.getName());
 		}
 		
@@ -149,6 +148,8 @@ public class DefaultRouteBindingHolderFactory implements
 		final Consumes consumes = method.getAnnotation(Consumes.class);
 		
 		final String finalPath = UriPathUtil.convertPath(path);
+
+		LOG.info(String.format("Added %s %s to be handled by %s.%s", httpMethod.value(), finalPath, clazz.getCanonicalName(), method.getName()));
 		
 		bindingHolder.addBinding(httpMethod, finalPath, consumes, produces, instance, clazz, method);
 	}

--- a/src/main/java/me/bayes/vertx/vest/handler/HttpServerRequestHandler.java
+++ b/src/main/java/me/bayes/vertx/vest/handler/HttpServerRequestHandler.java
@@ -1,0 +1,221 @@
+package me.bayes.vertx.vest.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import me.bayes.vertx.vest.binding.RouteBindingHolder;
+import me.bayes.vertx.vest.util.ParameterResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.vertx.java.core.Handler;
+import org.vertx.java.core.buffer.Buffer;
+import org.vertx.java.core.http.HttpServerRequest;
+import org.vertx.java.core.http.HttpServerResponse;
+import org.vertx.java.core.json.JsonObject;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+
+public class HttpServerRequestHandler implements Handler<HttpServerRequest> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HttpServerRequestHandler.class);
+
+    private final List<RouteBindingHolder.MethodBinding> bindings;
+    private List<RouteBindingHolder.MethodBinding> delegates;
+    private final ParameterResolver parameterResolver;
+    private final ObjectMapper objectMapper;
+
+    public HttpServerRequestHandler(List<RouteBindingHolder.MethodBinding> bindings, ParameterResolver parameterResolver,
+                                    ObjectMapper objectMapper) {
+        this.bindings = bindings;
+        this.delegates = bindings;
+        this.parameterResolver = parameterResolver;
+        this.objectMapper = objectMapper;
+    }
+
+    public void handle(HttpServerRequest request) {
+
+        try {
+            RouteBindingHolder.MethodBinding binding = null;
+            Method method;
+
+            String acceptsHeader = request.headers().get(HttpHeaders.ACCEPT);
+            String contentTypeHeader = request.headers().get(HttpHeaders.CONTENT_TYPE);
+
+            if (!request.headers().isEmpty()) {
+                for (RouteBindingHolder.MethodBinding binding_ : bindings) {
+                    if (binding_.hasConsumes(contentTypeHeader) && binding_.hasProduces(acceptsHeader)) {
+                        binding = binding_;
+                        break;
+                    }
+                    if (binding_.hasConsumes(contentTypeHeader) && acceptsHeader == null) {
+                        binding = binding_;
+                        break;
+                    }
+                    if (contentTypeHeader == null && binding_.hasProduces(acceptsHeader)) {
+                        binding = binding_;
+                        break;
+                    }
+                }
+
+            }
+
+            if (binding == null && delegates.size() > 0) {
+                binding = delegates.get(0);
+            } else if (binding == null) {
+                throw new Exception("No route that supports accepts given HTTP parameters");
+            }
+
+            method = binding.getMethod();
+
+            final Class<?>[] parameterTypes = method.getParameterTypes();
+            if (parameterTypes.length == 0 || !parameterTypes[0].equals(HttpServerRequest.class)) {
+                LOG.warn("Classes marked with a HttpMethod must have at least one parameter. The first parameter should be HttpServerRequest.");
+                return;
+            }
+
+            final Annotation[][] parameterAnnotations = method.getParameterAnnotations();
+            final String[] produces = binding.getProduces();
+            final String[] consumes = binding.getConsumes();
+            String producesMediaType = null;
+
+            if (acceptsHeader != null) {
+                if (produces != null && produces.length > 0) {
+                    for (String type : produces) {
+                        if (acceptsHeader.contains(type)) {
+                            producesMediaType = type;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (producesMediaType == null) {
+                producesMediaType =
+                        (produces != null && produces.length == 1) ?
+                                produces[0] : MediaType.TEXT_PLAIN;
+            }
+
+            if (contentTypeHeader != null) {
+                if (consumes != null && consumes.length > 0) {
+                    for (String type : consumes) {
+                        if (acceptsHeader.contains(type)) {
+                            contentTypeHeader = type;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            request.response().headers().set(HttpHeaders.CONTENT_TYPE, producesMediaType);
+
+            final Object[] parameters = new Object[parameterTypes.length];
+            parameters[0] = request;
+
+            boolean isBodyResolved = false;
+            boolean deserializeUsingJackson = false;
+            int objectParameterIndex = -1;
+
+            if (parameters.length > 1) {
+                for (int i = 1; i < parameters.length; i++) {
+                    if (hasJaxRsAnnotations(parameterAnnotations[i]) ||
+                            HttpServerResponse.class.equals(parameterTypes[i])) {
+
+                        parameters[i] = parameterResolver.resolve(method, parameterTypes[i], parameterAnnotations[i], request);
+
+                    } else if (JsonObject.class.equals(parameterTypes[i])) {
+                        objectParameterIndex = i;
+                        isBodyResolved = true;
+                        deserializeUsingJackson = false;
+                    } else {
+                        objectParameterIndex = i;
+                        isBodyResolved = true;
+                        deserializeUsingJackson = true;
+                    }
+                }
+            }
+
+            if (isBodyResolved) {
+                resolvedBodyDelegate(binding.getDelegate(), request, objectParameterIndex, method, parameters, parameterTypes, deserializeUsingJackson);
+            } else {
+                delegate(binding.getDelegate(), method, parameters);
+            }
+
+        } catch (Exception e) {
+            handleException(request, e);
+        }
+    }
+
+    private void delegate(Object delegate, Method method, Object[] parameters) throws IllegalAccessException, IllegalArgumentException, InvocationTargetException {
+        method.invoke(delegate, parameters);
+    }
+
+    private void resolvedBodyDelegate(final Object delegate, final HttpServerRequest request,
+                                      final int objectParameterIndex, final Method method,
+                                      final Object[] parameters, final Class<?>[] parameterTypes, final boolean deserializeUsingJackson) {
+
+        final Buffer buffer = new Buffer();
+
+        request.dataHandler(new Handler<Buffer>() {
+
+            @Override
+            public void handle(Buffer internalBuffer) {
+                buffer.appendBuffer(internalBuffer);
+            }
+
+        });
+
+        request.endHandler(new Handler<Void>() {
+
+            @Override
+            public void handle(Void event) {
+                String jsonString = buffer.toString();
+                if (deserializeUsingJackson) {
+                    try {
+                        parameters[objectParameterIndex] = objectMapper.readValue(jsonString, parameterTypes[objectParameterIndex]);
+                    } catch (IOException e) {
+                        handleException(request, e);
+                    }
+                } else {
+                    parameters[objectParameterIndex] = new JsonObject(jsonString);
+                }
+
+                try {
+                    method.invoke(delegate, parameters);
+                } catch (Exception e) {
+                    handleException(request, e);
+                }
+            }
+        });
+    }
+
+    private void handleException(HttpServerRequest request, Exception e) {
+        LOG.error("Exception occurred.", e);
+
+        request.response().headers().set(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_PLAIN);
+        request.response().setStatusCode(INTERNAL_SERVER_ERROR.code());
+        request.response().setStatusMessage(INTERNAL_SERVER_ERROR.reasonPhrase());
+        request.response().end();
+    }
+
+    private boolean hasJaxRsAnnotations(Annotation[] parameterAnnotation) {
+        for (Annotation annotation : parameterAnnotation) {
+            if (annotation.annotationType() == BeanParam.class ||
+                    annotation.annotationType() == CookieParam.class ||
+                    annotation.annotationType() == FormParam.class ||
+                    annotation.annotationType() == HeaderParam.class ||
+                    annotation.annotationType() == MatrixParam.class ||
+                    annotation.annotationType() == PathParam.class ||
+                    annotation.annotationType() == QueryParam.class) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/me/bayes/vertx/vest/util/DefaultParameterResolver.java
+++ b/src/main/java/me/bayes/vertx/vest/util/DefaultParameterResolver.java
@@ -15,24 +15,20 @@
  */
 package me.bayes.vertx.vest.util;
 
+import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 
 import javax.ws.rs.CookieParam;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.FormParam;
-import javax.ws.rs.HeaderParam;
 import javax.ws.rs.MatrixParam;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.QueryParam;
 
+import com.github.drapostolos.typeparser.TypeParser;
 import me.bayes.vertx.vest.VestApplication;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.vertx.java.core.http.HttpServerRequest;
 import org.vertx.java.core.http.HttpServerResponse;
-import org.vertx.java.core.json.JsonObject;
 
 /**
  * <pre>
@@ -66,12 +62,14 @@ public final class DefaultParameterResolver implements ParameterResolver {
 	 * @param request from vertx
 	 * @return object to populate
 	 */
-	public Object resolve(final Method method, final Class<?> parameterType, final Annotation[] annotations, final HttpServerRequest request) {
+	public Object resolve(final Method method, final Class<?> parameterType, final Annotation[] annotations, final HttpServerRequest request) throws IOException, ReflectiveOperationException {
 		
 		if(parameterType.equals(HttpServerResponse.class)) {
 			return new HttpServerResponseParameterHandler().handle(method, parameterType, annotations, request);
 		} else {
-			return new JaxrsAnnotationParamterHandler().handle(method, parameterType, annotations, request);
+			TypeParser typeParser = application.getSingleton(TypeParser.class);
+			return new JaxrsAnnotationParameterHandler(typeParser)
+					.handle(method, parameterType, annotations, request);
 		}
 		
 	}

--- a/src/main/java/me/bayes/vertx/vest/util/ParameterHandler.java
+++ b/src/main/java/me/bayes/vertx/vest/util/ParameterHandler.java
@@ -15,6 +15,7 @@
  */
 package me.bayes.vertx.vest.util;
 
+import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 
@@ -44,5 +45,5 @@ public interface ParameterHandler<R> {
 	 * @param request
 	 * @return
 	 */
-	R handle(final Method method, final Class<?> parameterType, final Annotation[] annotations, final HttpServerRequest request);
+	R handle(final Method method, final Class<?> parameterType, final Annotation[] annotations, final HttpServerRequest request) throws IOException, ReflectiveOperationException;
 }

--- a/src/main/java/me/bayes/vertx/vest/util/ParameterResolver.java
+++ b/src/main/java/me/bayes/vertx/vest/util/ParameterResolver.java
@@ -15,6 +15,7 @@
  */
 package me.bayes.vertx.vest.util;
 
+import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 
@@ -42,6 +43,6 @@ public interface ParameterResolver {
 	 * @param request which is the vertx {@link HttpServerRequest}
 	 * @return the resolved object
 	 */
-	Object resolve(final Method method, final Class<?> parameterType, final Annotation[] annotations, final HttpServerRequest request);
+	Object resolve(final Method method, final Class<?> parameterType, final Annotation[] annotations, final HttpServerRequest request) throws IOException, ReflectiveOperationException;
 
 }


### PR DESCRIPTION
According to JAX-RS, QueryParam and other annotations can be added to parameters of other types than String (https://docs.oracle.com/javaee/7/api/javax/ws/rs/QueryParam.html), so I implemented a way of casting the parameters to specific types.

In addition, _vest_ should be able to automatically deserialize request body to a specific object of a class. It is now supported using Jackson ObjectMapper object added using _addSingleton_ method.
